### PR TITLE
docs(zh-cn): fix api quickstart entry filename and run command

### DIFF
--- a/src/content/docs/zh-cn/guides/quickstart/api-service.md
+++ b/src/content/docs/zh-cn/guides/quickstart/api-service.md
@@ -75,7 +75,7 @@ user-api/
 │   │   └── getuserinfologic.go     # ← 在这里实现
 │   ├── svc/servicecontext.go
 │   └── types/types.go             # 从 DSL 自动生成
-└── main.go
+└── user.go
 ```
 
 ## 第三步：实现逻辑
@@ -110,7 +110,7 @@ func (l *GetUserInfoLogic) GetUserInfo(req *types.UserInfoReq) (resp *types.User
 ## 第四步：运行和测试
 
 ```bash
-go run main.go
+go run user.go
 ```
 
 在另一个终端中：


### PR DESCRIPTION
docs(zh-cn): align quickstart api-service with current goctl output
- replace main.go with user.go
- replace go run main.go with go run user.go