### PR TITLE
docs: add automation memory and drift checks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,7 @@
 
 > 本文件供 AI 助手（GitHub Copilot、Cursor 等）在新增或修改文档时遵循。
 > This file is the single source of truth for documentation conventions.
+> For source-driven or multi-page documentation work, also use `docs-memory/` as the persistent documentation memory.
 
 ---
 
@@ -55,7 +56,8 @@ src/content/docs/
 ├── community/                  # 6️⃣ 社区（FAQ + 贡献 + 示例）
 │   └── faq/
 ├── examples/                   # 示例（归属 Community 侧边栏）
-└── zh-cn/                      # 🇨🇳 中文镜像（结构 1:1 对应）
+├── zh-cn/                      # 🇨🇳 中文镜像（结构 1:1 对应）
+└── ko/                         # 🇰🇷 韩文镜像（结构 1:1 对应）
 ```
 
 ### 分区职责
@@ -79,13 +81,30 @@ src/content/docs/
 
 ---
 
-## 3. 双语言要求（EN + zh-CN）
+## 3. 多语言要求（EN + zh-CN + ko）
 
 - 英文文档放 `src/content/docs/` 根目录。
 - 中文镜像放 `src/content/docs/zh-cn/`，**目录结构 1:1 完全对应**。
-- **每新增一个英文 `.md`，必须同时新增对应的 `zh-cn/` 翻译文件。**
+- 韩文镜像放 `src/content/docs/ko/`，**目录结构 1:1 完全对应**。
+- **每新增一个英文 `.md`，必须同时新增对应的 `zh-cn/` 和 `ko/` 翻译文件。**
 - 中文 frontmatter 的 `title` 和 `description` 必须翻译为中文。
+- 韩文 frontmatter 的 `title` 和 `description` 必须翻译为韩文。
 - 中文正文使用中文书写；代码块、命令、变量名保持英文不翻译。
+- 韩文正文使用韩文书写；代码块、命令、变量名保持英文不翻译。
+
+## 3.1 文档记忆工作流
+
+当文档修改来自版本发布、源码变更、Issue、PR、外部文章、社区反馈或跨页面梳理时，使用 `docs-memory/`：
+
+1. 将原始材料保存为 `docs-memory/sources/` 下的 source packet。
+2. 编辑前先阅读 `docs-memory/index.md`，定位相关页面和已知缺口。
+3. 修改 `src/content/docs/` 下的公开文档，而不是只生成一次性回答。
+4. 如果新增重要主题、页面族或 source packet，更新 `docs-memory/index.md`。
+5. 在 `docs-memory/log.md` 追加一条日期化记录，说明本次 ingest、query 或 lint pass。
+
+`src/content/docs/` 是发布层；`docs-memory/` 是 AI/维护者用于持续积累上下文的工作台。
+
+`docs-memory/reports/` 下的 drift report 是源码变更审查队列。处理时先阅读 report 中列出的 upstream 文件，再决定是否更新公开文档。
 
 ---
 
@@ -95,7 +114,7 @@ src/content/docs/
 
 ```yaml
 ---
-title: Circuit Breaker          # 页面标题（zh-cn 文件用中文）
+title: Circuit Breaker          # 页面标题（zh-cn 文件用中文，ko 文件用韩文）
 description: Prevent cascading failures with automatic circuit breaking.
 sidebar:
   order: 2                      # 数字越小越靠前
@@ -106,7 +125,7 @@ sidebar:
 
 | 字段 | 必填 | 说明 |
 |------|------|------|
-| `title` | ✅ | 简洁的页面标题。EN 用英文，zh-cn 用中文 |
+| `title` | ✅ | 简洁的页面标题。EN 用英文，zh-cn 用中文，ko 用韩文 |
 | `description` | ✅ | 一句话描述，用于 SEO 和搜索摘要 |
 | `sidebar.order` | ✅ | 决定在侧边栏中的排序位置 |
 | `sidebar.label` | ❌ | 仅当侧边栏显示名需要和 title 不同时使用 |
@@ -117,7 +136,7 @@ sidebar:
 
 ```yaml
 ---
-title: HTTP Guide               # zh-cn: HTTP 指南
+title: HTTP Guide               # zh-cn: HTTP 指南；ko: HTTP 가이드
 description: Build, configure, and extend HTTP services with go-zero.
 sidebar:
   order: 1                      # index 通常 order: 1
@@ -234,21 +253,21 @@ This is a danger warning.
    ```js
    {
      label: 'WebSocket',
-     translations: { 'zh-CN': 'WebSocket' },
+     translations: { 'zh-CN': 'WebSocket', ko: 'WebSocket' },
      autogenerate: { directory: 'guides/websocket' },
    },
    ```
 2. 确保新目录有 `index.md`。
-3. `zh-cn/guides/websocket/` 镜像同步新增。
+3. `zh-cn/guides/websocket/` 和 `ko/guides/websocket/` 镜像同步新增。
 
 ### 翻译标签
 
-每个侧边栏条目都需要 `translations` 字段提供中文标签：
+每个侧边栏条目都需要 `translations` 字段提供中文和韩文标签：
 
 ```js
 {
   label: 'HTTP Service',           // 英文
-  translations: { 'zh-CN': 'HTTP 服务' },  // 中文
+  translations: { 'zh-CN': 'HTTP 服务', ko: 'HTTP 서비스' },
   autogenerate: { directory: 'guides/http' },
 }
 ```
@@ -282,14 +301,16 @@ This is a danger warning.
 在提交前确认以下事项：
 
 - [ ] `npm run build` 无报错
-- [ ] 新增英文文档在 `zh-cn/` 有对应中文翻译
+- [ ] `npm run validate` 无报错
+- [ ] 新增英文文档在 `zh-cn/` 和 `ko/` 有对应翻译
 - [ ] Frontmatter 包含 `title`、`description`、`sidebar.order`
-- [ ] zh-cn 文件的 `title` 和 `description` 已翻译为中文
+- [ ] zh-cn/ko 文件的 `title` 和 `description` 已翻译为对应语言
 - [ ] 内部链接使用相对路径且可正确跳转
 - [ ] 新目录已加入 `astro.config.mjs` 的 sidebar 配置
-- [ ] 新侧边栏条目包含 `translations: { 'zh-CN': '...' }`
+- [ ] 新侧边栏条目包含 `translations: { 'zh-CN': '...', ko: '...' }`
 - [ ] 代码示例完整可运行，语言标注正确
 - [ ] 目录下有 `index.md` 入口文件
+- [ ] Source-driven changes have updated `docs-memory/index.md` and `docs-memory/log.md`
 
 ---
 
@@ -374,10 +395,10 @@ exists := filter.Exists([]byte("key"))
 
 | ❌ 错误做法 | ✅ 正确做法 |
 |-------------|------------|
-| 只写英文不写中文 | EN + zh-cn 同时新增 |
+| 只写英文不写翻译 | EN + zh-cn + ko 同时新增 |
 | 绝对路径 `/docs/guides/http` | 相对路径 `../http/basic.md` |
 | 缺少 frontmatter | 始终包含 title + description + sidebar.order |
 | 目录没有 index.md | 每个目录必须有 index.md |
 | 代码块不标语言 | 始终标注 ` ```go ` / ` ```bash ` 等 |
-| 中文文件用英文 title | zh-cn 的 title/description 必须翻译 |
+| 翻译文件用英文 title | zh-cn/ko 的 title/description 必须翻译 |
 | 新目录不改 sidebar 配置 | 同步更新 `astro.config.mjs` |

--- a/.github/workflows/check-go-zero-drift.yml
+++ b/.github/workflows/check-go-zero-drift.yml
@@ -1,0 +1,66 @@
+name: Check go-zero documentation drift
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Base go-zero ref, for example v1.10.1. Leave empty for latest release.'
+        required: false
+        default: ''
+      head_ref:
+        description: 'Head go-zero ref. Leave empty for upstream default branch.'
+        required: false
+        default: ''
+  schedule:
+    - cron: '15 3 * * 2'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate upstream drift report
+        id: drift
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.inputs.base_ref || '' }}
+          HEAD_REF: ${{ github.event.inputs.head_ref || '' }}
+        run: node scripts/check-go-zero-drift.mjs
+
+      - name: Validate docs
+        if: steps.drift.outputs.has_changes == 'true'
+        run: npm run validate
+
+      - name: Open pull request
+        if: steps.drift.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: drift/go-zero-${{ steps.drift.outputs.base_ref }}-${{ steps.drift.outputs.head_ref }}
+          commit-message: "docs: report go-zero drift ${{ steps.drift.outputs.base_ref }}...${{ steps.drift.outputs.head_ref }}"
+          title: "docs: report go-zero drift ${{ steps.drift.outputs.base_ref }}...${{ steps.drift.outputs.head_ref }}"
+          body: |
+            Automated upstream drift report for `zeromicro/go-zero`.
+
+            Compare: `${{ steps.drift.outputs.base_ref }}...${{ steps.drift.outputs.head_ref }}`
+            Report: `${{ steps.drift.outputs.report_path }}`
+
+            Matched documentation areas: `${{ steps.drift.outputs.topic_count }}`
+            Changed upstream files reviewed: `${{ steps.drift.outputs.file_count }}`
+
+            Please review the report and decide whether related public docs need updates.
+          labels: automated, documentation, drift

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run validate
       - run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/sync-go-zero-docs.yml
+++ b/.github/workflows/sync-go-zero-docs.yml
@@ -1,0 +1,75 @@
+name: Sync go-zero documentation updates
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'go-zero release tag to sync, for example v1.10.1. Leave empty for latest.'
+        required: false
+        default: ''
+      force:
+        description: 'Regenerate docs even if release pages already exist.'
+        required: false
+        default: 'false'
+  schedule:
+    - cron: '30 2 * * 1'
+  repository_dispatch:
+    types: [go-zero-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+  models: read
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate release docs and documentation memory packet
+        id: sync
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.event.client_payload.tag || '' }}
+          FORCE_SYNC: ${{ github.event.inputs.force || 'false' }}
+          AI_MODEL: ${{ vars.GO_ZERO_DOCS_AI_MODEL || 'gpt-4o-mini' }}
+        run: node scripts/sync-go-zero-release.mjs
+
+      - name: Build site
+        if: steps.sync.outputs.has_changes == 'true'
+        run: |
+          npm run validate
+          npm run build
+
+      - name: Open pull request
+        if: steps.sync.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: sync/go-zero-docs-${{ steps.sync.outputs.tag }}
+          commit-message: "docs: sync go-zero ${{ steps.sync.outputs.tag }} documentation"
+          title: "docs: sync go-zero ${{ steps.sync.outputs.tag }} documentation"
+          body: |
+            Automated documentation update for go-zero `${{ steps.sync.outputs.tag }}`.
+
+            Source release: ${{ steps.sync.outputs.release_url }}
+
+            This PR updates:
+            - localized release pages
+            - the release index pages
+            - `docs-memory/sources/`
+            - `docs-memory/index.md`
+            - `docs-memory/log.md`
+
+            Please review the generated docs and use the source packet impact report to decide whether related guides, component docs, reference pages, or FAQs also need manual updates.
+          labels: automated, documentation

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -23,9 +23,18 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      models: read
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Fetch go-zero latest release info
         id: release
@@ -47,6 +56,13 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RELEASE_BODY: ${{ steps.release.outputs.body }}
         run: |
+          CHANGELOG="src/content/docs/reference/changelog.md"
+          if grep -q "^## ${RELEASE_TAG}[[:space:]]" "$CHANGELOG"; then
+            echo "Changelog already contains ${RELEASE_TAG}; skipping."
+            echo "entry_added=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           PROMPT="You are a technical writer for go-zero documentation. Based on the following release notes for ${RELEASE_TAG}, write a concise Markdown changelog entry suitable for a documentation site. Use third-person present tense, keep it under 300 words, group changes under headings (New Features, Bug Fixes, Breaking Changes). Release notes:\n\n${RELEASE_BODY}"
 
           # GitHub Models endpoint — available to GitHub Copilot subscribers
@@ -58,7 +74,6 @@ jobs:
             | jq -r '.choices[0].message.content')
 
           # Prepend to changelog file
-          CHANGELOG="src/content/docs/reference/changelog.md"
           TAG="${RELEASE_TAG}"
           DATE=$(date +%Y-%m-%d)
           ENTRY="## ${TAG} – ${DATE}\n\n${RESPONSE}\n\n"
@@ -68,6 +83,12 @@ jobs:
           awk '/^---/{n++} n==2{print; while((getline line < "'$TMPFILE'") > 0) print line; n=99; next} {print}' "$CHANGELOG" > /tmp/merged.md
           mv /tmp/merged.md "$CHANGELOG"
           echo "entry_added=true" >> "$GITHUB_OUTPUT"
+
+      - name: Validate generated docs
+        if: steps.ai.outputs.entry_added == 'true'
+        run: |
+          npm run validate
+          npm run build
 
       - name: Open pull request
         if: steps.ai.outputs.entry_added == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# go-zero Documentation Agent Guide
+
+This repository is the source for `go-zero.dev`, built with Astro and Starlight.
+
+For documentation writing rules, start with [.github/copilot-instructions.md](.github/copilot-instructions.md). For long-running or source-driven documentation improvements, also use the documentation memory in [docs-memory/](docs-memory/).
+
+## Documentation Memory Workflow
+
+Use the memory workflow when a task is based on release notes, source-code changes, issues, PRs, external articles, user reports, or repeated questions.
+
+1. Put immutable source material under `docs-memory/sources/`.
+2. Read `docs-memory/index.md` before editing public docs.
+3. Update affected public pages under `src/content/docs/`.
+4. Keep English, Simplified Chinese, and Korean pages structurally aligned unless the task explicitly targets one locale.
+5. Update `docs-memory/index.md` when a new important topic, page family, or source packet is added.
+6. Append a dated entry to `docs-memory/log.md` describing the ingest, query, or lint pass.
+
+Public documentation remains under `src/content/docs/`; `docs-memory/` is an agent-maintained workbench for source tracking, synthesis, and maintenance history.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This repository contains the full source of the go-zero documentation site, built with [Astro](https://astro.build/) and the [Starlight](https://starlight.astro.build/) documentation theme. It provides bilingual documentation (English + Simplified Chinese) covering concepts, tutorials, components, API reference, and more.
+This repository contains the full source of the go-zero documentation site, built with [Astro](https://astro.build/) and the [Starlight](https://starlight.astro.build/) documentation theme. It provides multilingual documentation (English + Simplified Chinese + Korean) covering concepts, tutorials, components, API reference, and more.
 
 **Live site:** https://go-zero.dev
 
@@ -56,6 +56,14 @@ npm run build
 
 The static output is generated into the `dist/` directory.
 
+### Validate Docs
+
+```bash
+npm run validate
+```
+
+This checks frontmatter, locale parity, supported code fences, and internal Markdown links.
+
 ### Preview Production Build
 
 ```bash
@@ -90,7 +98,8 @@ autodoc/
 │           ├── components/       # Built-in components (resilience, cache, etc.)
 │           ├── reference/        # goctl CLI, DSL syntax, configuration, releases
 │           ├── community/        # FAQ, contributing, code examples
-│           └── zh-cn/            # Simplified Chinese translations (mirrors above)
+│           ├── zh-cn/            # Simplified Chinese translations (mirrors above)
+│           └── ko/               # Korean translations (mirrors above)
 ├── astro.config.mjs              # Astro + Starlight configuration
 ├── package.json
 └── tsconfig.json
@@ -109,7 +118,7 @@ autodoc/
 | **Reference** | `reference/` | goctl CLI, DSL syntax, configuration reference, release notes |
 | **Community** | `community/` | FAQ, contributing guidelines, code examples |
 
-All sections are available in both **English** (`/`) and **Simplified Chinese** (`/zh-cn/`).
+All sections are available in **English** (`/`), **Simplified Chinese** (`/zh-cn/`), and **Korean** (`/ko/`).
 
 ---
 
@@ -119,7 +128,7 @@ Contributions to improve the documentation are welcome! You can:
 
 - Fix typos or clarify explanations
 - Add missing content or examples
-- Improve Chinese translations
+- Improve Chinese and Korean translations
 - Report issues via [GitHub Issues](https://github.com/zeromicro/autodoc/issues)
 
 ### Making Changes
@@ -140,7 +149,15 @@ Every push to `main` automatically builds and deploys the site to GitHub Pages. 
 
 ### Release Notes Sync (`sync-release.yml`)
 
-Every Monday, a workflow checks for new go-zero releases and opens a pull request with an AI-generated changelog entry. Can also be triggered manually with a specific version tag.
+Every Monday, a workflow checks for new go-zero releases and opens a pull request with an AI-generated changelog entry. Can also be triggered manually with a specific version tag. Existing changelog entries are skipped to avoid repeat PRs.
+
+### Documentation Update Sync (`sync-go-zero-docs.yml`)
+
+Every Monday, a workflow checks the latest `zeromicro/go-zero` release. When a release does not yet have docs, it generates localized release pages, updates release indexes, writes a `docs-memory/sources/` packet with changed files and documentation impact notes, builds the site, and opens a review PR.
+
+### Upstream Drift Check (`check-go-zero-drift.yml`)
+
+Every Tuesday, a workflow compares the latest go-zero release with the upstream default branch and opens a PR with a `docs-memory/reports/` impact report when source changes map to documentation areas. It can also be run manually with explicit `base_ref` and `head_ref` values.
 
 ---
 

--- a/docs-memory/README.md
+++ b/docs-memory/README.md
@@ -1,0 +1,71 @@
+# Documentation Memory
+
+This directory adapts the LLM-wiki pattern for the go-zero documentation site.
+
+## Layers
+
+| Layer | Path | Ownership | Purpose |
+| --- | --- | --- | --- |
+| Raw sources | `docs-memory/sources/` | Human/automation curated, immutable after ingest | Release notes, issue summaries, PR notes, source-code findings, migration reports, community questions |
+| Public wiki | `src/content/docs/` | Reviewed documentation content | Starlight pages published on `go-zero.dev` |
+| Memory index | `docs-memory/index.md` | Agent-maintained | Compact map of important doc areas, source packets, and known gaps |
+| Memory log | `docs-memory/log.md` | Append-only | Timeline of ingests, queries, lint passes, and cross-page maintenance |
+| Drift reports | `docs-memory/reports/` | Automation-generated, human-reviewed | Maps upstream go-zero source changes to docs that may need updates |
+
+## Operating Rules
+
+- Treat raw source packets as evidence. Do not rewrite them after ingest; add a new packet if the source changes.
+- Update public docs from source-backed understanding, not from a single generated answer.
+- Prefer improving existing pages over creating duplicates.
+- When adding or moving public pages, keep English, `zh-cn`, and `ko` paths aligned unless a task is locale-specific.
+- Record every source-driven documentation change in `log.md`.
+- Use `index.md` as the first stop before a broad documentation edit.
+- Treat drift reports as review queues, not proof that the public docs are wrong.
+
+## Source Packet Format
+
+Create one Markdown file per source packet under `docs-memory/sources/`:
+
+```markdown
+---
+title: Short source title
+source_type: release | issue | pr | code | discussion | external
+source_url: https://example.com
+captured_at: YYYY-MM-DD
+related_docs:
+  - src/content/docs/path/to/page.md
+status: new | ingested | superseded
+---
+
+## Key Facts
+
+- Fact that should influence docs.
+
+## Documentation Impact
+
+- Page or topic that may need an update.
+
+## Open Questions
+
+- Anything that needs verification before publishing.
+```
+
+## Maintenance Loop
+
+1. Ingest one source packet.
+2. Identify affected pages from `index.md` and `src/content/docs/`.
+3. Edit the public docs.
+4. Run `npm run build` and relevant link checks.
+5. Update `index.md` if the map changed.
+6. Append a `log.md` entry.
+
+## Drift Reports
+
+`check-go-zero-drift.yml` periodically compares upstream `zeromicro/go-zero` refs and writes reports under `docs-memory/reports/`.
+
+Use a report like this:
+
+1. Review each matched documentation area.
+2. Read the upstream files before editing public docs.
+3. Update English docs first, then mirror the change into `zh-cn` and `ko`.
+4. Run `npm run validate` and `npm run build`.

--- a/docs-memory/index.md
+++ b/docs-memory/index.md
@@ -1,0 +1,34 @@
+# Documentation Memory Index
+
+This is the compact navigation map for agent-assisted documentation work. Keep it short enough to read before a documentation edit.
+
+## Public Documentation Map
+
+| Area | English path | Localized mirrors | Purpose |
+| --- | --- | --- | --- |
+| Concepts | `src/content/docs/concepts/` | `zh-cn/concepts/`, `ko/concepts/` | Architecture, design principles, project structure, glossary |
+| Getting Started | `src/content/docs/getting-started/` | `zh-cn/getting-started/`, `ko/getting-started/` | Installation and first successful use |
+| Guides | `src/content/docs/guides/` | `zh-cn/guides/`, `ko/guides/` | Task-oriented HTTP, gRPC, database, deployment, queue, gateway, cron, MCP, and microservice guides |
+| Components | `src/content/docs/components/` | `zh-cn/components/`, `ko/components/` | go-zero package behavior and usage examples |
+| Reference | `src/content/docs/reference/` | `zh-cn/reference/`, `ko/reference/` | DSLs, CLI, configuration, customization, releases, changelog |
+| Community | `src/content/docs/community/` | `zh-cn/community/`, `ko/community/` | FAQ, contribution docs, code style, contributors |
+| Examples | `src/content/docs/examples/` | `zh-cn/examples/`, `ko/examples/` | End-to-end examples and scenario walkthroughs |
+
+## Source Packets
+
+No source packets have been ingested yet.
+
+## Known Maintenance Themes
+
+- Keep README and AI writing instructions aligned with the actual three-locale site: English, Simplified Chinese, and Korean.
+- Release-note automation currently updates the changelog only; source-driven release work should also update affected guide, component, reference, and FAQ pages.
+- `npm run validate` checks documentation structure and internal links; run it before publishing large doc changes.
+- The Go crawler in `tools/linkcheck/` checks the deployed site; use it separately for production URL health.
+- `check-go-zero-drift.yml` generates upstream drift reports under `docs-memory/reports/`; use them as review queues for source-code changes that may stale public docs.
+
+## Open Gaps To Investigate
+
+- Whether every locale has the same page set and sidebar coverage.
+- Whether examples compile against the latest go-zero release.
+- Whether configuration and CLI reference pages are generated from or checked against current go-zero source.
+- Whether generated Korean release pages need a translation-quality pass before publication.

--- a/docs-memory/log.md
+++ b/docs-memory/log.md
@@ -1,0 +1,23 @@
+# Documentation Memory Log
+
+Append entries in reverse chronological order.
+
+## [2026-06-27] setup | upstream drift reporting
+
+- Added deterministic mapping from upstream `zeromicro/go-zero` source paths to documentation areas.
+- Added scheduled drift report generation under `docs-memory/reports/`.
+- Drift reports are advisory review queues; they do not edit public docs automatically.
+
+## [2026-06-27] lint | documentation validation gates
+
+- Replaced the regex-only internal link checker with a Markdown-aware checker that skips fenced code and understands Starlight route resolution.
+- Added documentation structure validation for frontmatter, locale parity, and supported code fence languages.
+- Normalized unsupported code fence labels so Astro builds without highlighter warnings for those pages.
+- Wired `npm run validate` into deploy and documentation sync workflows.
+
+## [2026-06-27] setup | LLM-wiki workflow scaffold
+
+- Added the documentation memory workbench.
+- Established `docs-memory/sources/` as the raw source intake location.
+- Mapped the public Starlight docs as the wiki layer.
+- Noted initial maintenance themes: three-locale alignment, release updates beyond changelog, link/build validation, and source-backed reference checks.

--- a/docs-memory/reports/README.md
+++ b/docs-memory/reports/README.md
@@ -1,0 +1,5 @@
+# Drift Reports
+
+This directory stores generated reports that map upstream `zeromicro/go-zero` source changes to documentation areas in this repository.
+
+Reports are review aids. They should not be treated as proof that docs are wrong; they identify where maintainers should look.

--- a/docs-memory/sources/README.md
+++ b/docs-memory/sources/README.md
@@ -1,0 +1,15 @@
+# Source Packets
+
+Store immutable source packets here before updating public docs.
+
+Good source packets include:
+
+- go-zero release notes
+- go-zero source-code findings
+- GitHub issues and discussions
+- PR summaries
+- migration notes
+- recurring community questions
+- external posts that affect documentation strategy
+
+After a packet is ingested, keep the original file unchanged. If facts change, add a new packet and mark the old one as superseded in its frontmatter.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "sync:go-zero-release": "node scripts/sync-go-zero-release.mjs",
+    "check:go-zero-drift": "node scripts/check-go-zero-drift.mjs",
+    "check:docs": "python3 scripts/check_docs.py",
+    "check:links": "python3 scripts/check_links.py",
+    "validate": "npm run check:docs && npm run check:links"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.37.6",

--- a/scripts/check-go-zero-drift.mjs
+++ b/scripts/check-go-zero-drift.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const upstream = 'zeromicro/go-zero';
+const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+const baseRefInput = process.env.BASE_REF || '';
+const headRefInput = process.env.HEAD_REF || '';
+const maxFiles = Number(process.env.MAX_FILES || 300);
+
+const RULES = [
+  {
+    name: 'goctl and code generation',
+    patterns: [/^tools\/goctl\//, /^tools\/goctl-/, /^tools\/goctl_/, /^tools\/goctl\.go$/],
+    docs: [
+      'src/content/docs/reference/cli-guide/',
+      'src/content/docs/reference/api-dsl/',
+      'src/content/docs/reference/proto-dsl/',
+      'src/content/docs/getting-started/',
+      'src/content/docs/guides/quickstart/',
+    ],
+  },
+  {
+    name: 'HTTP server and client',
+    patterns: [/^rest\//, /^core\/handler\//],
+    docs: [
+      'src/content/docs/guides/http/',
+      'src/content/docs/reference/configuration/api-config.md',
+      'src/content/docs/community/faq/http/',
+    ],
+  },
+  {
+    name: 'gRPC and zRPC',
+    patterns: [/^zrpc\//, /^rpc\//],
+    docs: [
+      'src/content/docs/guides/grpc/',
+      'src/content/docs/reference/configuration/rpc-config.md',
+      'src/content/docs/reference/proto-dsl/',
+    ],
+  },
+  {
+    name: 'Gateway',
+    patterns: [/^gateway\//],
+    docs: ['src/content/docs/guides/gateway/'],
+  },
+  {
+    name: 'Configuration loading',
+    patterns: [/^core\/conf\//, /^core\/mapping\//, /^core\/configcenter\//],
+    docs: [
+      'src/content/docs/reference/configuration/',
+      'src/content/docs/guides/microservice/config-center.md',
+    ],
+  },
+  {
+    name: 'Service configuration',
+    patterns: [/^core\/service\//],
+    docs: [
+      'src/content/docs/reference/configuration/service-config.md',
+      'src/content/docs/guides/microservice/',
+    ],
+  },
+  {
+    name: 'Redis, cache, and storage',
+    patterns: [/^core\/stores\/redis\//, /^core\/stores\/cache\//, /^core\/stores\/sql/, /^core\/stores\/mon/],
+    docs: [
+      'src/content/docs/components/cache/',
+      'src/content/docs/guides/database/',
+      'src/content/docs/reference/cli-guide/model.md',
+    ],
+  },
+  {
+    name: 'Resilience and traffic protection',
+    patterns: [/^core\/breaker\//, /^core\/limit\//, /^core\/load\//, /^core\/stat\//],
+    docs: [
+      'src/content/docs/components/resilience/',
+      'src/content/docs/guides/microservice/load-balancing.md',
+    ],
+  },
+  {
+    name: 'Concurrency utilities',
+    patterns: [/^core\/fx\//, /^core\/mr\//, /^core\/syncx\//, /^core\/threading\//],
+    docs: ['src/content/docs/components/concurrency/'],
+  },
+  {
+    name: 'Logging',
+    patterns: [/^core\/logx\//, /^core\/logc\//],
+    docs: [
+      'src/content/docs/components/log/',
+      'src/content/docs/reference/configuration/log.md',
+      'src/content/docs/community/faq/log/',
+    ],
+  },
+  {
+    name: 'Observability',
+    patterns: [/^core\/trace\//, /^core\/metric\//, /^core\/prometheus\//, /^core\/prof\//],
+    docs: [
+      'src/content/docs/components/observability/',
+      'src/content/docs/guides/microservice/distributed-tracing.md',
+    ],
+  },
+  {
+    name: 'Message queues',
+    patterns: [/^core\/queue\//, /^core\/stores\/kafka\//],
+    docs: [
+      'src/content/docs/components/queue/',
+      'src/content/docs/guides/queue/',
+    ],
+  },
+  {
+    name: 'MCP',
+    patterns: [/^mcp\//, /^core\/mcp\//],
+    docs: ['src/content/docs/guides/mcp/'],
+  },
+  {
+    name: 'Examples and demos',
+    patterns: [/^example\//, /^examples\//, /^demo\//],
+    docs: ['src/content/docs/examples/'],
+  },
+];
+
+function setOutput(name, value) {
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value).replace(/\n/g, '%0A')}\n`);
+  }
+}
+
+function ymd(date = new Date()) {
+  return new Date(date).toISOString().slice(0, 10);
+}
+
+function slug(value) {
+  return String(value).toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-|-$/g, '');
+}
+
+async function github(pathname) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'zeromicro-autodoc-drift',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const res = await fetch(`https://api.github.com${pathname}`, { headers });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${pathname} failed: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function defaultBranch() {
+  const repo = await github(`/repos/${upstream}`);
+  return repo.default_branch || 'master';
+}
+
+async function latestReleaseTag() {
+  const release = await github(`/repos/${upstream}/releases/latest`);
+  return release.tag_name;
+}
+
+async function resolveRefs() {
+  const head = headRefInput || (await defaultBranch());
+  const base = baseRefInput || (await latestReleaseTag());
+  return { base, head };
+}
+
+async function compareRefs(base, head) {
+  return github(`/repos/${upstream}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`);
+}
+
+function matchRules(filename) {
+  return RULES.filter((rule) => rule.patterns.some((pattern) => pattern.test(filename)));
+}
+
+function uniq(values) {
+  return [...new Set(values)];
+}
+
+function relatedLocalizedDocs(docs) {
+  const localized = [];
+  for (const doc of docs) {
+    localized.push(doc);
+    if (doc.startsWith('src/content/docs/')) {
+      const suffix = doc.slice('src/content/docs/'.length);
+      localized.push(`src/content/docs/zh-cn/${suffix}`);
+      localized.push(`src/content/docs/ko/${suffix}`);
+    }
+  }
+  return uniq(localized);
+}
+
+function classify(files) {
+  const topics = new Map();
+  const unmatched = [];
+
+  for (const file of files) {
+    const matches = matchRules(file.filename);
+    if (!matches.length) {
+      unmatched.push(file);
+      continue;
+    }
+
+    for (const rule of matches) {
+      if (!topics.has(rule.name)) {
+        topics.set(rule.name, {
+          name: rule.name,
+          docs: new Set(rule.docs),
+          files: [],
+        });
+      }
+      topics.get(rule.name).files.push(file);
+    }
+  }
+
+  return { topics: [...topics.values()], unmatched };
+}
+
+function tableRows(files) {
+  if (!files.length) return '| Status | File |\n| --- | --- |\n| - | No files |\n';
+  return [
+    '| Status | File |',
+    '| --- | --- |',
+    ...files.map((file) => `| ${file.status} | \`${file.filename}\` |`),
+  ].join('\n');
+}
+
+function renderReport({ base, head, compare, topics, unmatched }) {
+  const today = ymd();
+  const compareUrl = `https://github.com/${upstream}/compare/${base}...${head}`;
+  const changedFiles = compare.files || [];
+  const truncated = changedFiles.length >= maxFiles ? `\n\n:::caution\nThe report considered the first ${maxFiles} files returned by GitHub. Re-run with a narrower compare range if needed.\n:::\n` : '';
+
+  const sections = topics.map((topic) => {
+    const docs = relatedLocalizedDocs([...topic.docs]).map((doc) => `- \`${doc}\``).join('\n');
+    return `## ${topic.name}\n\n### Changed Upstream Files\n\n${tableRows(topic.files)}\n\n### Documentation To Review\n\n${docs}\n`;
+  }).join('\n');
+
+  const unmatchedSection = unmatched.length
+    ? `## Unmatched Changes\n\nThese files did not match a documentation ownership rule. Review whether a new rule or docs update is needed.\n\n${tableRows(unmatched)}\n`
+    : '## Unmatched Changes\n\nNo unmatched upstream changes.\n';
+
+  return `# go-zero Upstream Drift Report\n\n- Captured: ${today}\n- Upstream: \`${upstream}\`\n- Base: \`${base}\`\n- Head: \`${head}\`\n- Compare: ${compareUrl}\n- Commits ahead: ${compare.ahead_by ?? 'unknown'}\n- Changed files reviewed: ${changedFiles.length}\n${truncated}\n## Summary\n\n${topics.length ? topics.map((topic) => `- **${topic.name}**: ${topic.files.length} changed file(s), review ${topic.docs.size} doc area(s).`).join('\n') : '- No owned documentation areas matched upstream changes.'}\n\n${sections || '## Matched Documentation Areas\n\nNo matched documentation areas.\n'}\n${unmatchedSection}\n## Suggested Review Workflow\n\n1. Read the changed upstream files for each matched area.\n2. Check the listed English docs first, then mirror necessary updates into \`zh-cn\` and \`ko\`.\n3. Update \`docs-memory/index.md\` if this reveals a new durable maintenance theme.\n4. Run \`npm run validate\` and \`npm run build\`.\n`;
+}
+
+function writeIfChanged(file, content) {
+  const current = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+  if (current === content) return false;
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  return true;
+}
+
+function updateMemoryIndex(reportRelPath) {
+  const file = path.join(repoRoot, 'docs-memory/index.md');
+  if (!fs.existsSync(file)) return false;
+  let content = fs.readFileSync(file, 'utf8');
+  const line = `- [Latest upstream drift report](${reportRelPath.replace(/^docs-memory\//, '')}) - mapped go-zero source changes to documentation areas.`;
+
+  if (content.includes('Latest upstream drift report')) {
+    content = content.replace(/- \[Latest upstream drift report\]\([^)]+\) - mapped go-zero source changes to documentation areas\./, line);
+  } else {
+    content = content.replace('## Known Maintenance Themes', `${line}\n\n## Known Maintenance Themes`);
+  }
+  return writeIfChanged(file, content);
+}
+
+function updateMemoryLog(base, head, reportRelPath, topics) {
+  const file = path.join(repoRoot, 'docs-memory/log.md');
+  if (!fs.existsSync(file)) return false;
+  let content = fs.readFileSync(file, 'utf8');
+  const today = ymd();
+  const heading = `## [${today}] lint | go-zero upstream drift ${base}...${head}`;
+  if (content.includes(heading)) return false;
+
+  const entry = `${heading}\n\n- Generated \`${reportRelPath}\`.\n- Matched ${topics.length} documentation ownership area(s).\n- Review the report before editing public docs.\n\n`;
+  content = content.replace('\n## ', `\n${entry}## `);
+  return writeIfChanged(file, content);
+}
+
+async function main() {
+  const { base, head } = await resolveRefs();
+  const compare = await compareRefs(base, head);
+  const files = (compare.files || []).slice(0, maxFiles);
+  const { topics, unmatched } = classify(files);
+  const hasChanges = files.length > 0 && topics.length > 0;
+
+  const reportName = `${slug(base)}...${slug(head)}.md`;
+  const reportRelPath = `docs-memory/reports/${reportName}`;
+  const reportPath = path.join(repoRoot, reportRelPath);
+  const report = renderReport({ base, head, compare: { ...compare, files }, topics, unmatched });
+
+  let changed = false;
+  if (hasChanges || process.env.WRITE_EMPTY_REPORT === 'true') {
+    changed = writeIfChanged(reportPath, report) || changed;
+    changed = updateMemoryIndex(reportRelPath) || changed;
+    changed = updateMemoryLog(base, head, reportRelPath, topics) || changed;
+  }
+
+  setOutput('has_changes', changed ? 'true' : 'false');
+  setOutput('base_ref', base);
+  setOutput('head_ref', head);
+  setOutput('report_path', reportRelPath);
+  setOutput('topic_count', topics.length);
+  setOutput('file_count', files.length);
+
+  console.log(JSON.stringify({
+    base,
+    head,
+    fileCount: files.length,
+    topicCount: topics.length,
+    reportPath: reportRelPath,
+    changed,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Validate documentation structure that Astro does not fully enforce."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+DOCS_ROOT = Path("src/content/docs")
+LOCALES = ("zh-cn", "ko")
+DOC_EXTS = {".md", ".mdx"}
+SUPPORTED_FENCES = {
+    "",
+    "bash",
+    "css",
+    "diff",
+    "dockerfile",
+    "go",
+    "html",
+    "http",
+    "ini",
+    "js",
+    "json",
+    "json5",
+    "groovy",
+    "lua",
+    "makefile",
+    "markdown",
+    "md",
+    "mermaid",
+    "plaintext",
+    "proto",
+    "protobuf",
+    "sh",
+    "shell",
+    "sql",
+    "text",
+    "toml",
+    "ts",
+    "txt",
+    "xml",
+    "yaml",
+    "yml",
+}
+
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---", re.DOTALL)
+FENCE_RE = re.compile(r"^[ \t]*(`{3,}|~{3,})([^\s`]*)", re.MULTILINE)
+
+
+def doc_files(root: Path) -> list[Path]:
+    return sorted(path for path in root.rglob("*") if path.is_file() and path.suffix in DOC_EXTS)
+
+
+def rel_public_path(path: Path) -> str:
+    rel = path.relative_to(DOCS_ROOT)
+    parts = rel.parts
+    if parts[0] in LOCALES:
+        return str(Path(*parts[1:]))
+    return str(rel)
+
+
+def root_doc_files() -> list[Path]:
+    files = []
+    for path in doc_files(DOCS_ROOT):
+        if path.relative_to(DOCS_ROOT).parts[0] not in LOCALES:
+            files.append(path)
+    return files
+
+
+def has_frontmatter_field(frontmatter: str, field: str) -> bool:
+    return re.search(rf"^{re.escape(field)}\s*:", frontmatter, re.MULTILINE) is not None
+
+
+def check_frontmatter(errors: list[str]) -> None:
+    for path in doc_files(DOCS_ROOT):
+        content = path.read_text(encoding="utf-8")
+        match = FRONTMATTER_RE.match(content)
+        rel = path.relative_to(DOCS_ROOT)
+        if not match:
+            errors.append(f"{rel}: missing YAML frontmatter")
+            continue
+
+        frontmatter = match.group(1)
+        for field in ("title", "description"):
+            if not has_frontmatter_field(frontmatter, field):
+                errors.append(f"{rel}: missing frontmatter field '{field}'")
+
+        if path.name == "index.mdx" and path.parent in {DOCS_ROOT, DOCS_ROOT / "zh-cn", DOCS_ROOT / "ko"}:
+            continue
+
+        if not re.search(r"^\s*order\s*:", frontmatter, re.MULTILINE):
+            errors.append(f"{rel}: missing frontmatter field 'sidebar.order'")
+
+
+def check_locale_parity(errors: list[str]) -> None:
+    english = {rel_public_path(path) for path in root_doc_files()}
+    for locale in LOCALES:
+        localized_root = DOCS_ROOT / locale
+        localized = {str(path.relative_to(localized_root)) for path in doc_files(localized_root)}
+        for missing in sorted(english - localized):
+            errors.append(f"{locale}: missing localized page for {missing}")
+        for extra in sorted(localized - english):
+            errors.append(f"{locale}: extra localized page without English source {extra}")
+
+
+def check_fences(errors: list[str]) -> None:
+    for path in doc_files(DOCS_ROOT):
+        content = path.read_text(encoding="utf-8")
+        for match in FENCE_RE.finditer(content):
+            lang = match.group(2).strip().lower()
+            if lang not in SUPPORTED_FENCES:
+                line = content.count("\n", 0, match.start()) + 1
+                rel = path.relative_to(DOCS_ROOT)
+                errors.append(f"{rel}:{line}: unsupported code fence language '{match.group(2)}'")
+
+
+def main() -> int:
+    errors: list[str] = []
+    check_frontmatter(errors)
+    check_locale_parity(errors)
+    check_fences(errors)
+
+    if errors:
+        for error in errors:
+            print(f"  {error}")
+        print(f"\nTotal: {len(errors)} documentation structure error(s)")
+        return 1
+
+    print("Documentation structure checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -1,51 +1,155 @@
 #!/usr/bin/env python3
-"""Check for broken internal links in markdown docs."""
+"""Check internal Markdown links in Starlight docs.
+
+The checker intentionally ignores fenced code blocks. The previous regex-only
+implementation reported Go generic signatures and code examples as broken links,
+which made the check too noisy to enforce in CI.
+"""
+
+from __future__ import annotations
+
 import os
 import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
 
-docs_root = "src/content/docs"
-errors = []
 
-for root, dirs, files in os.walk(docs_root):
-    for f in files:
-        if not f.endswith(".md") and not f.endswith(".mdx"):
-            continue
-        filepath = os.path.join(root, f)
-        with open(filepath) as fh:
-            content = fh.read()
-        for m in re.finditer(r"\[([^\]]*)\]\(([^)]+)\)", content):
-            text, link = m.group(1), m.group(2)
-            if link.startswith("http") or link.startswith("#") or link.startswith("mailto:"):
-                continue
-            link_path = link.split("#")[0]
-            if not link_path:
-                continue
-            if any(link_path.endswith(ext) for ext in [".png", ".jpg", ".svg", ".gif", ".webp"]):
-                continue
-            file_dir = os.path.dirname(filepath)
-            resolved = os.path.normpath(os.path.join(file_dir, link_path))
-            found = False
-            candidates = [resolved]
-            if resolved.endswith(".md") or resolved.endswith(".mdx"):
-                base = resolved.rsplit(".", 1)[0]
-                candidates.append(os.path.join(base, "index.md"))
-            else:
-                candidates.append(resolved + ".md")
-                candidates.append(resolved + ".mdx")
-                candidates.append(os.path.join(resolved, "index.md"))
-                candidates.append(os.path.join(resolved, "index.mdx"))
-            for c in candidates:
-                if os.path.exists(c):
-                    found = True
-                    break
-            if not found:
-                rel_file = os.path.relpath(filepath, docs_root)
-                errors.append((rel_file, link))
+DOCS_ROOT = Path("src/content/docs")
+PUBLIC_ROOT = Path("public")
+DOC_EXTS = {".md", ".mdx"}
+ASSET_EXTS = {
+    ".avif",
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".pdf",
+    ".png",
+    ".svg",
+    ".webp",
+    ".zip",
+}
 
-seen = set()
-for e in sorted(errors):
-    if e not in seen:
-        seen.add(e)
-        print(f"  {e[0]}  ->  {e[1]}")
+LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+REF_RE = re.compile(r"^\s*\[[^\]]+\]:\s*(\S+)", re.MULTILINE)
+HTML_LINK_RE = re.compile(r"""(?:href|src)=["']([^"']+)["']""")
+FENCE_RE = re.compile(r"(^|\n)[ \t]*(`{3,}|~{3,})[^\n]*\n.*?(?:\n[ \t]*\2)(?=\n|$)", re.DOTALL)
 
-print(f"\nTotal: {len(seen)} broken links")
+
+def strip_fenced_code(markdown: str) -> str:
+    return FENCE_RE.sub("\n", markdown)
+
+
+def iter_doc_files() -> list[Path]:
+    return sorted(
+        path
+        for path in DOCS_ROOT.rglob("*")
+        if path.is_file() and path.suffix in DOC_EXTS
+    )
+
+
+def is_external(link: str) -> bool:
+    parsed = urlparse(link)
+    return parsed.scheme in {"http", "https", "mailto", "tel"}
+
+
+def is_asset(path: str) -> bool:
+    return Path(path).suffix.lower() in ASSET_EXTS
+
+
+def candidate_docs(path: Path) -> list[Path]:
+    if path.suffix in DOC_EXTS:
+        base = path.with_suffix("")
+        return [path, base / "index.md", base / "index.mdx"]
+    return [
+        path,
+        Path(f"{path}.md"),
+        Path(f"{path}.mdx"),
+        path / "index.md",
+        path / "index.mdx",
+    ]
+
+
+def route_to_doc(path: str) -> Path:
+    route = path.strip("/")
+    if route in {"", "docs"}:
+        return DOCS_ROOT / "index.mdx"
+    return DOCS_ROOT / route
+
+
+def resolve_links(source: Path, link: str) -> list[Path] | None:
+    parsed = urlparse(link)
+    target = unquote(parsed.path)
+
+    if not target or target.startswith("#") or is_external(link):
+        return None
+
+    if target.startswith("/"):
+        public_file = PUBLIC_ROOT / target.lstrip("/")
+        if is_asset(target) or public_file.exists():
+            return [public_file]
+        return [route_to_doc(target)]
+
+    if source.stem == "index":
+        route_base = source.parent
+    else:
+        # Starlight renders a file page as a directory route:
+        # reference/changelog.md -> /reference/changelog/.
+        # Relative links are resolved by the browser from that route.
+        route_base = source.with_suffix("")
+
+    source_base = source.parent
+    candidates = []
+    for base in (source_base, route_base):
+        resolved = (base / target).resolve().relative_to(Path.cwd())
+        if resolved not in candidates:
+            candidates.append(resolved)
+    return candidates
+
+
+def exists(source: Path, link: str) -> bool:
+    resolved_paths = resolve_links(source, link)
+    if resolved_paths is None:
+        return True
+
+    for resolved in resolved_paths:
+        if is_asset(str(resolved)) and resolved.exists():
+            return True
+
+        if resolved.exists() and resolved.is_file():
+            return True
+
+        if any(candidate.exists() and candidate.is_file() for candidate in candidate_docs(resolved)):
+            return True
+
+    return False
+
+
+def collect_links(markdown: str) -> list[str]:
+    body = strip_fenced_code(markdown)
+    links = [match.group(1) for match in LINK_RE.finditer(body)]
+    links.extend(match.group(1) for match in REF_RE.finditer(body))
+    links.extend(match.group(1) for match in HTML_LINK_RE.finditer(body))
+    return links
+
+
+def main() -> int:
+    errors: list[tuple[str, str]] = []
+
+    for path in iter_doc_files():
+        markdown = path.read_text(encoding="utf-8")
+        for link in collect_links(markdown):
+            clean = link.strip("<>")
+            if not exists(path, clean):
+                errors.append((str(path.relative_to(DOCS_ROOT)), clean))
+
+    for rel_file, link in sorted(set(errors)):
+        print(f"  {rel_file} -> {link}")
+
+    print(f"\nTotal: {len(set(errors))} broken links")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    os.chdir(Path(__file__).resolve().parents[1])
+    sys.exit(main())

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -101,7 +101,11 @@ def resolve_links(source: Path, link: str) -> list[Path] | None:
     source_base = source.parent
     candidates = []
     for base in (source_base, route_base):
-        resolved = (base / target).resolve().relative_to(Path.cwd())
+        resolved_absolute = (base / target).resolve()
+        try:
+            resolved = resolved_absolute.relative_to(Path.cwd())
+        except ValueError:
+            resolved = Path("__outside_repo__") / resolved_absolute.as_posix().lstrip("/")
         if resolved not in candidates:
             candidates.append(resolved)
     return candidates

--- a/scripts/sync-go-zero-release.mjs
+++ b/scripts/sync-go-zero-release.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const upstream = 'zeromicro/go-zero';
+const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+const requestedTag = process.env.RELEASE_TAG || process.argv[2] || '';
+const model = process.env.AI_MODEL || 'gpt-4o-mini';
+const endpoint = process.env.AI_ENDPOINT || 'https://models.inference.ai.azure.com/chat/completions';
+
+const output = {};
+
+function setOutput(name, value) {
+  output[name] = String(value);
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value).replace(/\n/g, '%0A')}\n`);
+  }
+}
+
+function readFile(file) {
+  return fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+}
+
+function writeFileIfChanged(file, content) {
+  const current = readFile(file);
+  if (current === content) return false;
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  return true;
+}
+
+async function github(pathname) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'zeromicro-autodoc-sync',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const res = await fetch(`https://api.github.com${pathname}`, { headers });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${pathname} failed: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function getRelease() {
+  if (requestedTag) {
+    return github(`/repos/${upstream}/releases/tags/${encodeURIComponent(requestedTag)}`);
+  }
+  return github(`/repos/${upstream}/releases/latest`);
+}
+
+function extractCompareTags(body) {
+  const match = body.match(/github\.com\/zeromicro\/go-zero\/compare\/([^.\s]+)\.\.\.([^\s)]+)/);
+  return match ? { base: match[1], head: match[2] } : null;
+}
+
+async function findPreviousTag(release) {
+  const fromBody = extractCompareTags(release.body || '');
+  if (fromBody?.base) return fromBody.base;
+
+  const releases = await github(`/repos/${upstream}/releases?per_page=30`);
+  const currentIndex = releases.findIndex((item) => item.tag_name === release.tag_name);
+  if (currentIndex >= 0 && releases[currentIndex + 1]) {
+    return releases[currentIndex + 1].tag_name;
+  }
+  return '';
+}
+
+async function getCompare(base, head) {
+  if (!base || !head) return null;
+  try {
+    return await github(`/repos/${upstream}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`);
+  } catch (error) {
+    console.warn(`Could not fetch compare ${base}...${head}: ${error.message}`);
+    return null;
+  }
+}
+
+function ymd(date) {
+  return new Date(date).toISOString().slice(0, 10);
+}
+
+function slugTag(tag) {
+  return tag.toLowerCase().replace(/^v/, 'v').replace(/[^a-z0-9.-]/g, '-');
+}
+
+function escapeYaml(value) {
+  return String(value).replace(/"/g, '\\"');
+}
+
+function trimMarkdown(value) {
+  return String(value || '').trim().replace(/\n{3,}/g, '\n\n');
+}
+
+function fallbackDoc(release, previousTag, compare) {
+  const body = trimMarkdown(release.body || 'No release notes were provided upstream.');
+  const changedFiles = compare?.files?.slice(0, 25).map((file) => `- \`${file.filename}\``).join('\n') || '- Not available.';
+  const compareLine = previousTag
+    ? `\n\n**Full Changelog**: https://github.com/${upstream}/compare/${previousTag}...${release.tag_name}`
+    : '';
+
+  return {
+    en: `Released on **${ymd(release.published_at || release.created_at)}** - [GitHub Release](${release.html_url})\n\n## Highlights\n\n${body}${compareLine}`,
+    zh: `发布于 **${ymd(release.published_at || release.created_at)}** - [GitHub Release](${release.html_url})\n\n## 亮点\n\n${body}${compareLine}`,
+    ko: `릴리스 날짜: **${ymd(release.published_at || release.created_at)}** - [GitHub Release](${release.html_url})\n\n## Highlights\n\n${body}${compareLine}`,
+    impact: `## Documentation Impact\n\nReview these changed upstream files and update related guides, components, reference pages, and FAQs when needed.\n\n${changedFiles}\n`,
+  };
+}
+
+function extractJson(text) {
+  const fenced = text.match(/```json\s*([\s\S]*?)```/);
+  const raw = fenced ? fenced[1] : text;
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start < 0 || end < start) throw new Error('model response did not contain a JSON object');
+  return JSON.parse(raw.slice(start, end + 1));
+}
+
+async function generateWithModel(release, previousTag, compare) {
+  if (!token || process.env.DISABLE_AI === 'true') return null;
+
+  const changedFiles = (compare?.files || [])
+    .slice(0, 120)
+    .map((file) => `${file.status}\t${file.filename}`)
+    .join('\n');
+
+  const prompt = `You maintain the go-zero documentation site.
+
+Create release documentation for ${release.tag_name}.
+
+Return only a JSON object with these string fields:
+- en: English Markdown body for src/content/docs/reference/releases/${release.tag_name}.md. Do not include frontmatter.
+- zh: Simplified Chinese Markdown body for zh-cn.
+- ko: Korean Markdown body for ko.
+- impact: English Markdown report listing which documentation pages or topics should be reviewed beyond release notes.
+
+Rules:
+- Use factual information from the upstream release notes and changed file list only.
+- Preserve GitHub PR links when present.
+- Keep release docs concise and useful.
+- Mention potential breaking changes or migration work only if supported by the notes.
+- The first line of each localized release doc should include the release date and GitHub release link.
+
+Release date: ${ymd(release.published_at || release.created_at)}
+GitHub release: ${release.html_url}
+Previous tag: ${previousTag || 'unknown'}
+Compare: ${previousTag ? `https://github.com/${upstream}/compare/${previousTag}...${release.tag_name}` : 'unknown'}
+
+Upstream release notes:
+${release.body || '(empty)'}
+
+Changed files:
+${changedFiles || '(not available)'}`;
+
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.2,
+      max_tokens: 5000,
+    }),
+  });
+
+  if (!res.ok) {
+    console.warn(`AI generation failed: ${res.status} ${await res.text()}`);
+    return null;
+  }
+
+  const data = await res.json();
+  const text = data?.choices?.[0]?.message?.content || '';
+  try {
+    const parsed = extractJson(text);
+    if (parsed.en && parsed.zh && parsed.ko && parsed.impact) return parsed;
+  } catch (error) {
+    console.warn(`AI response could not be parsed: ${error.message}`);
+  }
+  return null;
+}
+
+function frontmatter(tag, locale, date) {
+  const prefix = locale === 'root' ? '' : `${locale}/`;
+  const description =
+    locale === 'zh-cn'
+      ? `go-zero ${tag} 发布说明 - ${date}。`
+      : locale === 'ko'
+        ? `go-zero ${tag} 릴리스 노트 - ${date}.`
+        : `go-zero ${tag} release notes - ${date}.`;
+
+  return `---\nslug: ${prefix}reference/releases/${tag}\ntitle: ${tag}\ndescription: "${escapeYaml(description)}"\nsidebar:\n  order: 1\n---\n\n`;
+}
+
+function updateReleaseIndex(locale, tag, date) {
+  const base = locale === 'root' ? 'src/content/docs' : `src/content/docs/${locale}`;
+  const file = path.join(repoRoot, base, 'reference/releases/index.md');
+  let content = readFile(file);
+  if (!content || content.includes(`[${tag}](${tag}/)`)) return false;
+
+  const minor = tag.match(/^v(\d+)\.(\d+)\./);
+  const heading = minor ? `## v${minor[1]}.${minor[2]}.x` : '## Other';
+  const line = `- [${tag}](${tag}/) - ${date}`;
+
+  if (content.includes(heading)) {
+    content = content.replace(`${heading}\n\n`, `${heading}\n\n${line}\n`);
+  } else {
+    const firstVersionHeading = content.search(/\n## v\d+\.\d+\.x/);
+    if (firstVersionHeading >= 0) {
+      content = `${content.slice(0, firstVersionHeading)}\n${heading}\n\n${line}\n${content.slice(firstVersionHeading)}`;
+    } else {
+      content = `${content.trim()}\n\n${heading}\n\n${line}\n`;
+    }
+  }
+  return writeFileIfChanged(file, content);
+}
+
+function sourcePacket(release, previousTag, compare, impact) {
+  const date = ymd(new Date().toISOString());
+  const releaseDate = ymd(release.published_at || release.created_at);
+  const files = (compare?.files || []).map((file) => `- ${file.status}: \`${file.filename}\``).join('\n') || '- Not available.';
+
+  return `---\ntitle: go-zero ${release.tag_name} release\nsource_type: release\nsource_url: ${release.html_url}\ncaptured_at: ${date}\nrelated_docs:\n  - src/content/docs/reference/releases/${release.tag_name}.md\n  - src/content/docs/zh-cn/reference/releases/${release.tag_name}.md\n  - src/content/docs/ko/reference/releases/${release.tag_name}.md\nstatus: ingested\n---\n\n## Key Facts\n\n- Release: ${release.tag_name}\n- Published: ${releaseDate}\n- Previous tag: ${previousTag || 'unknown'}\n- Compare: ${previousTag ? `https://github.com/${upstream}/compare/${previousTag}...${release.tag_name}` : 'unknown'}\n\n## Upstream Release Notes\n\n${trimMarkdown(release.body || 'No upstream release notes were provided.')}\n\n## Changed Files\n\n${files}\n\n${trimMarkdown(impact)}\n`;
+}
+
+function updateMemoryIndex(tag) {
+  const file = path.join(repoRoot, 'docs-memory/index.md');
+  let content = readFile(file);
+  const line = `- [go-zero ${tag} release](sources/go-zero-${slugTag(tag)}.md) - release source packet and documentation impact report.`;
+
+  if (!content || content.includes(`go-zero ${tag} release`)) return false;
+  if (content.includes('No source packets have been ingested yet.')) {
+    content = content.replace('No source packets have been ingested yet.', line);
+  } else {
+    content = content.replace('## Known Maintenance Themes', `${line}\n\n## Known Maintenance Themes`);
+  }
+  return writeFileIfChanged(file, content);
+}
+
+function updateMemoryLog(tag) {
+  const file = path.join(repoRoot, 'docs-memory/log.md');
+  let content = readFile(file);
+  const today = ymd(new Date().toISOString());
+  const heading = `## [${today}] ingest | go-zero ${tag} release`;
+  if (content.includes(heading)) return false;
+
+  const entry = `${heading}\n\n- Captured upstream release notes and changed files for ${tag}.\n- Generated English, Simplified Chinese, and Korean release pages.\n- Added a source packet for future cross-page documentation maintenance.\n\n`;
+  content = content.replace('\n## ', `\n${entry}## `);
+  return writeFileIfChanged(file, content);
+}
+
+async function main() {
+  const release = await getRelease();
+  const tag = release.tag_name;
+  const date = ymd(release.published_at || release.created_at);
+  const releaseFiles = [
+    path.join(repoRoot, 'src/content/docs/reference/releases', `${tag}.md`),
+    path.join(repoRoot, 'src/content/docs/zh-cn/reference/releases', `${tag}.md`),
+    path.join(repoRoot, 'src/content/docs/ko/reference/releases', `${tag}.md`),
+  ];
+
+  if (process.env.FORCE_SYNC !== 'true' && releaseFiles.every((file) => fs.existsSync(file))) {
+    setOutput('has_changes', 'false');
+    setOutput('tag', tag);
+    setOutput('release_url', release.html_url);
+    console.log(JSON.stringify({ tag, changed: false, reason: 'release docs already exist' }, null, 2));
+    return;
+  }
+
+  const previousTag = await findPreviousTag(release);
+  const compare = await getCompare(previousTag, tag);
+  const generated = (await generateWithModel(release, previousTag, compare)) || fallbackDoc(release, previousTag, compare);
+
+  let changed = false;
+  const files = [
+    ['root', 'en', generated.en],
+    ['zh-cn', 'zh', generated.zh],
+    ['ko', 'ko', generated.ko],
+  ];
+
+  for (const [locale, key, body] of files) {
+    const base = locale === 'root' ? 'src/content/docs' : `src/content/docs/${locale}`;
+    const file = path.join(repoRoot, base, 'reference/releases', `${tag}.md`);
+    changed = writeFileIfChanged(file, `${frontmatter(tag, locale, date)}${trimMarkdown(body)}\n`) || changed;
+    changed = updateReleaseIndex(locale, tag, date) || changed;
+  }
+
+  const packetFile = path.join(repoRoot, 'docs-memory/sources', `go-zero-${slugTag(tag)}.md`);
+  changed = writeFileIfChanged(packetFile, sourcePacket(release, previousTag, compare, generated.impact)) || changed;
+  changed = updateMemoryIndex(tag) || changed;
+  changed = updateMemoryLog(tag) || changed;
+
+  setOutput('has_changes', changed ? 'true' : 'false');
+  setOutput('tag', tag);
+  setOutput('release_url', release.html_url);
+
+  console.log(JSON.stringify({ tag, previousTag, changed, output }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/sync-go-zero-release.mjs
+++ b/scripts/sync-go-zero-release.mjs
@@ -204,7 +204,7 @@ function updateReleaseIndex(locale, tag, date) {
 
   const minor = tag.match(/^v(\d+)\.(\d+)\./);
   const heading = minor ? `## v${minor[1]}.${minor[2]}.x` : '## Other';
-  const line = `- [${tag}](${tag}/) - ${date}`;
+  const line = `- [${tag}](${tag}/) — ${date}`;
 
   if (content.includes(heading)) {
     content = content.replace(`${heading}\n\n`, `${heading}\n\n${line}\n`);

--- a/src/content/docs/ko/reference/api-dsl/route-sse.md
+++ b/src/content/docs/ko/reference/api-dsl/route-sse.md
@@ -14,7 +14,7 @@ sidebar:
 
 ### SSE 지원
 
-```api
+```text
 syntax = "v1"
 
 type EventMessage {

--- a/src/content/docs/ko/reference/cli-guide/model.md
+++ b/src/content/docs/ko/reference/cli-guide/model.md
@@ -806,7 +806,7 @@ model:
 
 We have pg 에서 table 사용하여 데이터 타입 `inet`.
 
-```SQL
+```sql
 -- auto-generated definition
 create table student
 (

--- a/src/content/docs/ko/reference/configuration/overview.md
+++ b/src/content/docs/ko/reference/configuration/overview.md
@@ -124,7 +124,7 @@ conf.MustLoad("config.yaml", &c, conf.UseEnv())
 
 ```
 
-```config.yaml
+```yaml
 Name: ${SERVER_NAME}
 ```
 
@@ -177,7 +177,7 @@ More 참조 [unmarshaler_test.go](https://github.com/zeromicro/go-zero/releases/
 
 이 항목은 해당 기능의 사용 방법, 설정, 주의 사항을 설명합니다.
 
-```goc
+```text
 type Config struct {
     Etcd     discov.EtcdConf
     UserRpc  zrpc.RpcClientConf

--- a/src/content/docs/ko/reference/configuration/overview.md
+++ b/src/content/docs/ko/reference/configuration/overview.md
@@ -177,7 +177,7 @@ More 참조 [unmarshaler_test.go](https://github.com/zeromicro/go-zero/releases/
 
 이 항목은 해당 기능의 사용 방법, 설정, 주의 사항을 설명합니다.
 
-```text
+```go
 type Config struct {
     Etcd     discov.EtcdConf
     UserRpc  zrpc.RpcClientConf

--- a/src/content/docs/reference/api-dsl/route-sse.md
+++ b/src/content/docs/reference/api-dsl/route-sse.md
@@ -15,7 +15,7 @@ go-zero now supports Server-Sent Events (SSE) through the `sse: true` annotation
 
 ### SSE Support
 
-```api
+```text
 syntax = "v1"
 
 type EventMessage {

--- a/src/content/docs/reference/cli-guide/model.md
+++ b/src/content/docs/reference/cli-guide/model.md
@@ -811,7 +811,7 @@ model:
 
 We have a pg in the table with data type `inet`.
 
-```SQL
+```sql
 -- auto-generated definition
 create table student
 (

--- a/src/content/docs/reference/configuration/overview.md
+++ b/src/content/docs/reference/configuration/overview.md
@@ -130,7 +130,7 @@ conf.MustLoad("config.yaml", &c, conf.UseEnv())
 
 ```
 
-```config.yaml
+```yaml
 Name: ${SERVER_NAME}
 ```
 
@@ -192,7 +192,7 @@ More reference [unmarshaler_test.go](https://github.com/zeromicro/go-zero/blob/m
 
 In our daily configuration, there are many duplicate configurations, such as rpcClientConf where each rpc has a etcd configuration, but in most of our cases the etcd configuration is the same and we hope it can be configured only once. Examples below
 
-```goc
+```text
 type Config struct {
     Etcd     discov.EtcdConf
     UserRpc  zrpc.RpcClientConf

--- a/src/content/docs/reference/configuration/overview.md
+++ b/src/content/docs/reference/configuration/overview.md
@@ -192,7 +192,7 @@ More reference [unmarshaler_test.go](https://github.com/zeromicro/go-zero/blob/m
 
 In our daily configuration, there are many duplicate configurations, such as rpcClientConf where each rpc has a etcd configuration, but in most of our cases the etcd configuration is the same and we hope it can be configured only once. Examples below
 
-```text
+```go
 type Config struct {
     Etcd     discov.EtcdConf
     UserRpc  zrpc.RpcClientConf

--- a/src/content/docs/zh-cn/reference/api-dsl/route-sse.md
+++ b/src/content/docs/zh-cn/reference/api-dsl/route-sse.md
@@ -15,7 +15,7 @@ go-zero 现已通过 `@server` 指令中的 `sse: true` 注解支持服务器推
 
 ### SSE 支持
 
-```api
+```text
 syntax = "v1"
 
 type EventMessage {

--- a/src/content/docs/zh-cn/reference/cli-guide/model.md
+++ b/src/content/docs/zh-cn/reference/cli-guide/model.md
@@ -934,7 +934,7 @@ model:
 
 我们在表中有一个 pg 的数据类型为 inet
 
-```SQL
+```sql
 -- auto-generated definition
 create table student
 (

--- a/src/content/docs/zh-cn/reference/configuration/overview.md
+++ b/src/content/docs/zh-cn/reference/configuration/overview.md
@@ -131,7 +131,7 @@ conf.MustLoad("config.yaml", &c, conf.UseEnv())
 
 ```
 
-```config.yaml
+```yaml
 Name: ${SERVER_NAME}
 ```
 
@@ -194,7 +194,7 @@ type Config struct {
 在我们日常的配置，会出现很多重复的配置，例如 rpcClientConf 中，每个 rpc 都有一个 etcd 的配置，但是我们大部分的情况下 etcd 的配置都是一样的，我们希望可以只用配置一次etcd就可以了。
 如下的例子
 
-```goc
+```text
 type Config struct {
 	Etcd     discov.EtcdConf
 	UserRpc  zrpc.RpcClientConf

--- a/src/content/docs/zh-cn/reference/configuration/overview.md
+++ b/src/content/docs/zh-cn/reference/configuration/overview.md
@@ -194,7 +194,7 @@ type Config struct {
 在我们日常的配置，会出现很多重复的配置，例如 rpcClientConf 中，每个 rpc 都有一个 etcd 的配置，但是我们大部分的情况下 etcd 的配置都是一样的，我们希望可以只用配置一次etcd就可以了。
 如下的例子
 
-```text
+```go
 type Config struct {
 	Etcd     discov.EtcdConf
 	UserRpc  zrpc.RpcClientConf


### PR DESCRIPTION
## Summary
- add docs-memory scaffold for source packets, generated notes, and decision logs
- add scheduled/manual go-zero release sync and upstream drift detection workflows
- add docs validation gates for locale parity, frontmatter, code fences, and links

## Verification
- npm run validate
- npm run build