### PR TITLE
docs: fix sidebar overview ordering

### DIFF
--- a/docs-memory/log.md
+++ b/docs-memory/log.md
@@ -2,6 +2,12 @@
 
 Append entries in reverse chronological order.
 
+## [2026-08-09] remediation | sidebar overview ordering
+
+- Revisited the sidebar-order finding from go-zero issue #5672 and conflicted autodoc PR #25.
+- Moved all guide and component overview pages before their child pages across English, Simplified Chinese, and Korean.
+- Split a malformed Simplified Chinese microservice list item while retaining locale-correct relative tracing links.
+
 ## [2026-08-09] lint | CI, release automation, and validation hardening
 
 - Consolidated overlapping release workflows into one localized, idempotent documentation sync.

--- a/src/content/docs/components/cache/index.md
+++ b/src/content/docs/components/cache/index.md
@@ -2,7 +2,7 @@
 title: Cache Components
 description: In-process and distributed caching components for go-zero.
 sidebar:
-  order: 4
+  order: 0
 
 ---
 

--- a/src/content/docs/components/concurrency/index.md
+++ b/src/content/docs/components/concurrency/index.md
@@ -2,7 +2,7 @@
 title: Concurrency
 description: Concurrency primitives and parallel processing utilities in go-zero.
 sidebar:
-  order: 5
+  order: 0
 
 ---
 

--- a/src/content/docs/components/log/index.md
+++ b/src/content/docs/components/log/index.md
@@ -2,7 +2,7 @@
 title: Log Components
 description: Structured logging components for go-zero.
 sidebar:
-  order: 6
+  order: 0
 
 ---
 

--- a/src/content/docs/components/observability/index.md
+++ b/src/content/docs/components/observability/index.md
@@ -2,7 +2,7 @@
 title: Observability Components
 description: Logging, metrics, and tracing components for go-zero.
 sidebar:
-  order: 7
+  order: 0
 
 ---
 

--- a/src/content/docs/components/queue/index.md
+++ b/src/content/docs/components/queue/index.md
@@ -2,7 +2,7 @@
 title: Queue Components
 description: Message queue components for go-zero.
 sidebar:
-  order: 8
+  order: 0
 
 ---
 

--- a/src/content/docs/components/resilience/index.md
+++ b/src/content/docs/components/resilience/index.md
@@ -2,7 +2,7 @@
 title: Resilience Components
 description: "Fault tolerance components for go-zero: circuit breaker, rate limiter, timeout, load shedding."
 sidebar:
-  order: 9
+  order: 0
 
 ---
 

--- a/src/content/docs/guides/cron-job/index.md
+++ b/src/content/docs/guides/cron-job/index.md
@@ -2,7 +2,7 @@
 title: Cron Jobs
 description: Run scheduled tasks with go-zero on Kubernetes.
 sidebar:
-  order: 20
+  order: 0
 
 ---
 

--- a/src/content/docs/guides/database/index.md
+++ b/src/content/docs/guides/database/index.md
@@ -2,7 +2,7 @@
 title: Database Guide
 description: Connect go-zero services to MongoDB, MySQL, and Redis.
 sidebar:
-  order: 15
+  order: 0
 
 ---
 

--- a/src/content/docs/guides/grpc/index.md
+++ b/src/content/docs/guides/grpc/index.md
@@ -2,7 +2,7 @@
 title: gRPC Guide
 description: Build, configure, and extend gRPC services with go-zero.
 sidebar:
-  order: 3
+  order: 0
 
 ---
 

--- a/src/content/docs/guides/http/index.md
+++ b/src/content/docs/guides/http/index.md
@@ -2,7 +2,7 @@
 title: HTTP Guide
 description: Build, configure, and extend HTTP services with go-zero.
 sidebar:
-  order: 2
+  order: 0
 
 ---
 

--- a/src/content/docs/guides/mcp/index.md
+++ b/src/content/docs/guides/mcp/index.md
@@ -2,7 +2,7 @@
 title: MCP Guide
 description: Build Model Context Protocol (MCP) servers with go-zero.
 sidebar:
-  order: 21
+  order: 0
 
 ---
 

--- a/src/content/docs/guides/microservice/index.md
+++ b/src/content/docs/guides/microservice/index.md
@@ -2,7 +2,7 @@
 title: Microservice Guide
 description: Implement microservice patterns with go-zero — service discovery, load balancing, and distributed tracing.
 sidebar:
-  order: 10
+  order: 0
 
 ---
 

--- a/src/content/docs/guides/queue/index.md
+++ b/src/content/docs/guides/queue/index.md
@@ -2,7 +2,7 @@
 title: Queue Guide
 description: Use message queues and delay queues in go-zero services.
 sidebar:
-  order: 16
+  order: 0
 
 ---
 

--- a/src/content/docs/guides/quickstart/index.md
+++ b/src/content/docs/guides/quickstart/index.md
@@ -2,7 +2,7 @@
 title: Quick Start
 description: Build your first go-zero services in under 5 minutes.
 sidebar:
-  order: 1
+  order: 0
 ---
 
 ## Tutorials

--- a/src/content/docs/ko/components/cache/index.md
+++ b/src/content/docs/ko/components/cache/index.md
@@ -2,7 +2,7 @@
 title: 캐시 컴포넌트
 description: go-zero의 메모리 캐시와 Redis 캐시 사용법입니다.
 sidebar:
-  order: 4
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/components/concurrency/index.md
+++ b/src/content/docs/ko/components/concurrency/index.md
@@ -2,7 +2,7 @@
 title: 동시성
 description: go-zero의 동시성에 대해 설명합니다.
 sidebar:
-  order: 5
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/components/log/index.md
+++ b/src/content/docs/ko/components/log/index.md
@@ -2,7 +2,7 @@
 title: 로그 컴포넌트
 description: go-zero의 구조화 로깅과 컨텍스트 기반 로깅 기능입니다.
 sidebar:
-  order: 6
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/components/observability/index.md
+++ b/src/content/docs/ko/components/observability/index.md
@@ -2,7 +2,7 @@
 title: 관측 가능성 컴포넌트
 description: go-zero의 로그, 메트릭, 추적, 프로파일링 기능입니다.
 sidebar:
-  order: 7
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/components/queue/index.md
+++ b/src/content/docs/ko/components/queue/index.md
@@ -2,7 +2,7 @@
 title: 큐 컴포넌트
 description: go-zero에서 Kafka와 RabbitMQ 같은 메시지 큐를 사용하는 방법입니다.
 sidebar:
-  order: 8
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/components/resilience/index.md
+++ b/src/content/docs/ko/components/resilience/index.md
@@ -2,7 +2,7 @@
 title: 탄력성 컴포넌트
 description: 장애 전파를 줄이고 과부하를 제어하는 go-zero 탄력성 컴포넌트입니다.
 sidebar:
-  order: 9
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/guides/cron-job/index.md
+++ b/src/content/docs/ko/guides/cron-job/index.md
@@ -2,7 +2,7 @@
 title: Cron 작업
 description: go-zero의 Cron 작업에 대해 설명합니다.
 sidebar:
-  order: 20
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/guides/database/index.md
+++ b/src/content/docs/ko/guides/database/index.md
@@ -2,7 +2,7 @@
 title: 데이터베이스 가이드
 description: go-zero의 데이터베이스 가이드에 대해 설명합니다.
 sidebar:
-  order: 15
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/guides/grpc/index.md
+++ b/src/content/docs/ko/guides/grpc/index.md
@@ -2,7 +2,7 @@
 title: gRPC 가이드
 description: go-zero의 gRPC 가이드에 대해 설명합니다.
 sidebar:
-  order: 3
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/guides/http/index.md
+++ b/src/content/docs/ko/guides/http/index.md
@@ -2,7 +2,7 @@
 title: HTTP 가이드
 description: go-zero로 HTTP 서비스를 만들고, 설정하고, 확장하는 방법입니다.
 sidebar:
-  order: 2
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/guides/mcp/index.md
+++ b/src/content/docs/ko/guides/mcp/index.md
@@ -2,7 +2,7 @@
 title: MCP 가이드
 description: go-zero의 MCP 가이드에 대해 설명합니다.
 sidebar:
-  order: 21
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/guides/microservice/index.md
+++ b/src/content/docs/ko/guides/microservice/index.md
@@ -2,7 +2,7 @@
 title: Microservice 가이드
 description: go-zero의 Microservice 가이드에 대해 설명합니다.
 sidebar:
-  order: 10
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/guides/queue/index.md
+++ b/src/content/docs/ko/guides/queue/index.md
@@ -2,7 +2,7 @@
 title: 큐 가이드
 description: go-zero의 큐 가이드에 대해 설명합니다.
 sidebar:
-  order: 16
+  order: 0
 
 ---
 

--- a/src/content/docs/ko/guides/quickstart/index.md
+++ b/src/content/docs/ko/guides/quickstart/index.md
@@ -2,7 +2,7 @@
 title: 빠른 시작
 description: 5분 안에 첫 go-zero 서비스를 만들어 봅니다.
 sidebar:
-  order: 1
+  order: 0
 ---
 
 ## 튜토리얼

--- a/src/content/docs/zh-cn/components/cache/index.md
+++ b/src/content/docs/zh-cn/components/cache/index.md
@@ -2,7 +2,7 @@
 title: 缓存组件
 description: go-zero 进程内和分布式缓存组件。
 sidebar:
-  order: 4
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/components/concurrency/index.md
+++ b/src/content/docs/zh-cn/components/concurrency/index.md
@@ -2,7 +2,7 @@
 title: 并发工具
 description: go-zero 并发原语与并行处理工具。
 sidebar:
-  order: 5
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/components/log/index.md
+++ b/src/content/docs/zh-cn/components/log/index.md
@@ -2,7 +2,7 @@
 title: 日志组件
 description: go-zero 结构化日志组件。
 sidebar:
-  order: 6
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/components/observability/index.md
+++ b/src/content/docs/zh-cn/components/observability/index.md
@@ -2,7 +2,7 @@
 title: 可观测性组件
 description: go-zero 可观测性组件：日志、指标、链路追踪。
 sidebar:
-  order: 7
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/components/queue/index.md
+++ b/src/content/docs/zh-cn/components/queue/index.md
@@ -2,7 +2,7 @@
 title: 队列组件
 description: go-zero 消息队列组件。
 sidebar:
-  order: 8
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/components/resilience/index.md
+++ b/src/content/docs/zh-cn/components/resilience/index.md
@@ -2,7 +2,7 @@
 title: 服务韧性组件
 description: go-zero 容错组件：熔断器、限流器、超时控制、负载削减。
 sidebar:
-  order: 9
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/guides/cron-job/index.md
+++ b/src/content/docs/zh-cn/guides/cron-job/index.md
@@ -2,7 +2,7 @@
 title: 定时任务
 description: 在 Kubernetes 上使用 go-zero 运行定时任务。
 sidebar:
-  order: 20
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/guides/database/index.md
+++ b/src/content/docs/zh-cn/guides/database/index.md
@@ -2,7 +2,7 @@
 title: 数据库指南
 description: 将 go-zero 服务连接到 MongoDB、MySQL 和 Redis。
 sidebar:
-  order: 15
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/guides/grpc/index.md
+++ b/src/content/docs/zh-cn/guides/grpc/index.md
@@ -2,7 +2,7 @@
 title: gRPC 指南
 description: 使用 go-zero 构建、配置和扩展 gRPC 服务。
 sidebar:
-  order: 3
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/guides/http/index.md
+++ b/src/content/docs/zh-cn/guides/http/index.md
@@ -2,7 +2,7 @@
 title: HTTP 指南
 description: 使用 go-zero 构建、配置和扩展 HTTP 服务。
 sidebar:
-  order: 2
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/guides/mcp/index.md
+++ b/src/content/docs/zh-cn/guides/mcp/index.md
@@ -2,7 +2,7 @@
 title: MCP 指南
 description: 使用 go-zero 构建 MCP (Model Context Protocol) 服务端。
 sidebar:
-  order: 21
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/guides/microservice/index.md
+++ b/src/content/docs/zh-cn/guides/microservice/index.md
@@ -2,7 +2,7 @@
 title: 微服务指南
 description: 使用 go-zero 实现微服务模式——服务发现、负载均衡和分布式链路追踪。
 sidebar:
-  order: 10
+  order: 0
 
 ---
 
@@ -14,4 +14,5 @@ go-zero 内置支持常见的微服务模式，包括通过 etcd 进行服务发
 
 - [服务发现](service-discovery/) — 注册和发现服务
 - [负载均衡](load-balancing/) — 配置客户端负载均衡
-- [链路追踪](distributed-tracing/) — 为微服务添加追踪- [配置中心](config-center/) — 使用 etcd 管理动态配置
+- [链路追踪](distributed-tracing/) — 为微服务添加追踪
+- [配置中心](config-center/) — 使用 etcd 管理动态配置

--- a/src/content/docs/zh-cn/guides/queue/index.md
+++ b/src/content/docs/zh-cn/guides/queue/index.md
@@ -2,7 +2,7 @@
 title: 消息队列指南
 description: 在 go-zero 服务中使用消息队列和延迟队列。
 sidebar:
-  order: 16
+  order: 0
 
 ---
 

--- a/src/content/docs/zh-cn/guides/quickstart/index.md
+++ b/src/content/docs/zh-cn/guides/quickstart/index.md
@@ -2,7 +2,7 @@
 title: 快速入门
 description: 5 分钟内构建你的第一个 go-zero 服务。
 sidebar:
-  order: 1
+  order: 0
 ---
 
 ## 教程


### PR DESCRIPTION
Replaces #25 on top of current main.\n\n- puts every guide and component overview before its child pages in all three locales\n- fixes the malformed Simplified Chinese microservice list item\n- retains the repository-compliant relative tracing links already on main\n- records the remediation in documentation memory\n\nValidation:\n- npm test\n- npm run validate\n- npm run build\n- git diff --check